### PR TITLE
Minor changes to remove warning messages while importing ImageFeatures.jl

### DIFF
--- a/src/lbp.jl
+++ b/src/lbp.jl
@@ -116,7 +116,7 @@ function multi_block_lbp{T<:Gray}(img::AbstractArray{T, 2}, tl_y::Integer, tl_x:
 	lbp_code
 end
 
-function _create_descriptor{T<:FixedPointNumbers.UFixed}(img::AbstractArray{Gray{T}, 2}, yblocks::Integer = 4, xblocks = 4, lbp_type::Function = lbp, args...)
+function _create_descriptor{T<:FixedPointNumbers.Normed}(img::AbstractArray{Gray{T}, 2}, yblocks::Integer = 4, xblocks = 4, lbp_type::Function = lbp, args...)
 	h, w = size(img)
     blockh = ceil(Int, h / (yblocks))
     blockw = ceil(Int, w / (xblocks))
@@ -134,7 +134,7 @@ function _create_descriptor{T<:FixedPointNumbers.UFixed}(img::AbstractArray{Gray
     descriptor
 end
 
-function create_descriptor{T<:FixedPointNumbers.UFixed}(img::AbstractArray{Gray{T}, 2}, yblocks::Integer = 4, xblocks = 4; lbp_type::Function = lbp, args...)
+function create_descriptor{T<:FixedPointNumbers.Normed}(img::AbstractArray{Gray{T}, 2}, yblocks::Integer = 4, xblocks = 4; lbp_type::Function = lbp, args...)
     h, w = size(img)
     y_padded = ceil(Int, h / (yblocks)) * yblocks
     x_padded = ceil(Int, w / (xblocks)) * xblocks


### PR DESCRIPTION
Just changed some deprecated types to remove the warning messages shown while importing ImageFeatures.jl