### PR TITLE
Fix non-leaftype in ORB and turn off coverage in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ notifications:
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.add("Distributions")'  # Needed for Docs and Tests
-    - julia -e 'Pkg.add("TestImages")'  # Needed for Docs 
+    - julia -e 'Pkg.add("TestImages")'  # Needed for Docs
     - julia -e 'Pkg.add("ImageMagick")'  # Needed for Docs
-    - julia -e 'Pkg.add("Images")'  # Needed for Docs 
-    - julia -e 'Pkg.clone("https://github.com/JuliaImages/ImageDraw.jl")' # Needed for Docs 
+    - julia -e 'Pkg.add("Images")'  # Needed for Docs
+    - julia -e 'Pkg.clone("https://github.com/JuliaImages/ImageDraw.jl")' # Needed for Docs
     - julia -e 'Pkg.clone(pwd()); Pkg.build("ImageFeatures")'
-    - julia -e 'Pkg.test("ImageFeatures",coverage=true)'
+    - julia -e 'Pkg.test("ImageFeatures", coverage=false)'
 after_success:
-    - if [ $TRAVIS_OS_NAME = "linux" ]; then
-         julia -e 'cd(Pkg.dir("ImageFeatures")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-      fi
+    # - if [ $TRAVIS_OS_NAME = "linux" ]; then
+    #      julia -e 'cd(Pkg.dir("ImageFeatures")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+    #   fi
     - julia -e 'Pkg.add("Documenter")'
     - julia -e 'cd(Pkg.dir("ImageFeatures")); include(joinpath("docs", "make.jl"))'

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,6 @@
 FactCheck
 TestImages
 @linux ImageMagick
+@windows ImageMagick
 @osx QuartzImageIO
 Distributions


### PR DESCRIPTION
I was trying to see if I could improve the performance of the ORB tests with `Pkg.test("ImageFeatures", coverage=true)`, which really comes down to improving performance when running julia with `julia --check-bounds=yes --inline=no`. Sadly, this doesn't seem to be easy, but at least I found a way to speed up ORB substantially when running under "normal" conditions.

So (after adding the performance improvement) I just turned off coverage in the tests. I think it's more important to have tests than to measure coverage; we can do that locally if we have to.