### PR TITLE
added hough circle function

### DIFF
--- a/src/ImageFeatures.jl
+++ b/src/ImageFeatures.jl
@@ -60,6 +60,9 @@ export
     gaussian_local,
     center_sample,
 
-    #Lines and Ellipses
+    #Lines
     hough_transform_standard
+
+    #Circles
+    hough_circle_gradient
 end

--- a/src/ImageFeatures.jl
+++ b/src/ImageFeatures.jl
@@ -61,7 +61,7 @@ export
     center_sample,
 
     #Lines
-    hough_transform_standard
+    hough_transform_standard,
 
     #Circles
     hough_circle_gradient

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -102,7 +102,20 @@ Parameters:
 -   `scale`        = relative accumulator resolution factor  
 -   `min_dist`     = minimum distance between detected circle centers  
 -   `vote_thres`   = accumulator threshold for circle detection  
--   `min_radius:max_radius`   = circle radius range  
+-   `min_radius:max_radius`   = circle radius range
+
+[`canny`](@ref) and [`phase`](@ref) can be used for obtaining img_edges and img_phase respectively.
+
+# Example
+```julia
+img = load("circle.png")
+
+img_edges = canny(img, 1, 0.99, 0.97)
+dx, dy=imgradients(img, KernelFactors.ando5)
+img_phase = phase(dx, dy)
+
+centers, radii=hough_circle_gradient(img_edges, img_phase, 1, 60, 60, 3:50)
+```
 """  
 
 function hough_circle_gradient{T<:Number}(

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -163,7 +163,7 @@ function hough_circle_gradient{T<:Number}(
 
     f = CartesianIndex(map(r->first(r), indices(votes)))
     l = CartesianIndex(map(r->last(r), indices(votes)))
-    radius_votes=Vector{Int}(Int(floor(dist(f,l))+1))
+    radius_votes=Vector{Int}(Int(floor(dist(f,l)/scale)+1))
 
     for center in centers
         center=(center-1)*scale
@@ -181,11 +181,14 @@ function hough_circle_gradient{T<:Number}(
         end
 
         for point in non_zeros
-            radius_votes[Int(floor(dist(center, point)/scale))+1]+=1
+            r=Int(floor(dist(center, point)/scale))
+            if radii.start/scale<=r<=radii.stop/scale
+                radius_votes[r+1]+=1
+            end
         end
 
         voters, radius = findmax(radius_votes)
-        radius-=1
+        radius=(radius-1)*scale;
 
         if voters>vote_thres
             push!(circle_centers, center)

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -118,9 +118,6 @@ function hough_circle_gradient{T<:Number}(
     circle_radius=Int[]
     votes=zeros(Int, Int(floor(rows/scale))+1, Int(floor(cols/scale))+1)
 
-    f = CartesianIndex(map(r->first(r), indices(votes)))
-    l = CartesianIndex(map(r->last(r), indices(votes)))
-
     function vote!(votes, x, y)
         fx = Int(floor(x))
         fy = Int(floor(y))

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -94,7 +94,7 @@ circle_centers, circle_radius = hough_circle_gradient(img_edges, img_phase, scal
 Returns two vectors, corresponding to circle centers and radius.  
   
 The circles are generated using a hough transform variant in which a non-zero point only votes for circle  
-centers perpendicular to the local gradient.  
+centers perpendicular to the local gradient. In case of concentric circles, only the largest circle is detected.
   
 Parameters:  
 -   `img_edges`    = edges of the image  

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -160,6 +160,9 @@ function hough_circle_gradient{T<:Number}(
     sort!(centers, lt=(a, b) -> votes[a]>votes[b])
 
     dist(a, b) = sqrt(sum(abs2, (a-b).I))
+
+    f = CartesianIndex(map(r->first(r), indices(votes)))
+    l = CartesianIndex(map(r->last(r), indices(votes)))
     radius_votes=Vector{Int}(Int(floor(dist(f,l))+1))
 
     for center in centers
@@ -191,3 +194,4 @@ function hough_circle_gradient{T<:Number}(
     end
     return circle_centers, circle_radius
 end
+

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -157,7 +157,9 @@ function hough_circle_gradient{T<:Number}(
         end
     end
 
-    sort!(centers, lt=(a, b) -> votes[a]>votes[b])
+    @noinline sort_by_votes(centers, votes) = sort!(centers, lt=(a, b) -> votes[a]>votes[b])
+
+    sort_by_votes(centers, votes)
 
     dist(a, b) = sqrt(sum(abs2, (a-b).I))
 

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -137,7 +137,7 @@ function hough_circle_gradient{T<:Number}(
 
     for j in indices(img_edges, 2)::AbstractUnitRange{Int}
         for i in indices(img_edges, 1)::AbstractUnitRange{Int}
-            if img_edges[i,j]!=0
+            if img_edges[i,j]
                 sin_theta = -cos(img_phase[i,j]);
                 cos_theta = sin(img_phase[i,j]);
 
@@ -164,7 +164,7 @@ function hough_circle_gradient{T<:Number}(
     sort!(centers, lt=(a, b) -> votes[a]>votes[b])
 
     dist(a, b) = sqrt(sum(abs2, (a-b).I))
-    radius_votes=Array(Int, Int(floor(dist(f,l))+1))
+    radius_votes=Vector{Int}(Int(floor(dist(f,l))+1))
 
     for center in centers
         center=(center-1)*scale

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -106,8 +106,8 @@ Parameters:
     max_radius   = maximum circle radius
 """
 
-function hough_circle_gradient{N<:Bool, T<:Number}(
-        img_edges::AbstractArray{N,2}, img_phase::AbstractArray{T,2},
+function hough_circle_gradient{T<:Number}(
+        img_edges::AbstractArray{Bool,2}, img_phase::AbstractArray{T,2},
         scale::Number, min_dist::Number,
         vote_thres::Number, radii::AbstractVector{Int})
 

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -134,8 +134,8 @@ function hough_circle_gradient{T<:Number}(
         end
     end
 
-    for j in indices(img_edges, 2)::AbstractUnitRange{Int}
-        for i in indices(img_edges, 1)::AbstractUnitRange{Int}
+    for j in indices(img_edges, 2)
+        for i in indices(img_edges, 1)
             if img_edges[i,j]
                 sinθ = -cos(img_phase[i,j]);
                 cosθ = sin(img_phase[i,j]);

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -127,6 +127,40 @@ function hough_circle_gradient{T<:Integer}(
     f = CartesianIndex(map(r->first(r), indices(votes)))
     l = CartesianIndex(map(r->last(r), indices(votes)))
 
+    function vote!(img, x, y)
+        i=Int(floor(x))+1
+        j=Int(floor(y))+1
+        p=CartesianIndex(i,j)
+
+        if min(f,p)==f && max(l,p)==l
+            votes[p]+=1
+        end
+
+        i=Int(floor(x))+2
+        j=Int(floor(y))+1
+        p=CartesianIndex(i,j)
+
+        if min(f,p)==f && max(l,p)==l
+            votes[p]+=1
+        end
+
+        i=Int(floor(x))+1
+        j=Int(floor(y))+2
+        p=CartesianIndex(i,j)
+
+        if min(f,p)==f && max(l,p)==l
+            votes[p]+=1
+        end
+
+        i=Int(floor(x))+2
+        j=Int(floor(y))+2
+        p=CartesianIndex(i,j)
+
+        if min(f,p)==f && max(l,p)==l
+            votes[p]+=1
+        end
+    end
+
     for i in indices(img, 1)
         for j in indices(img, 2)
             if img_edges[i,j]!=0
@@ -134,21 +168,13 @@ function hough_circle_gradient{T<:Integer}(
                 cos_theta = sin(img_phase[i,j]);
 
                 for r in min_radius:max_radius
-                    x=Int(floor((i+r*sin_theta)/scale))+1
-                    y=Int(floor((j+r*cos_theta)/scale))+1
-                    p=CartesianIndex(x,y)
+                    x=(i+r*sin_theta)/scale
+                    y=(j+r*cos_theta)/scale
+                    vote!(img, x, y)
 
-                    if min(f,p)==f && max(l,p)==l
-                        votes[p]+=1
-                    end
-
-                    x=Int(floor((i-r*sin_theta)/scale))+1
-                    y=Int(floor((j-r*cos_theta)/scale))+1
-                    p=CartesianIndex(x,y)
-
-                    if min(f,p)==f && max(l,p)==l
-                        votes[p]+=1
-                    end
+                    x=(i-r*sin_theta)/scale
+                    y=(j-r*cos_theta)/scale
+                    vote!(img, x, y)
                 end
                 push!(non_zeros, CartesianIndex{2}(i,j));
             end
@@ -178,7 +204,7 @@ function hough_circle_gradient{T<:Integer}(
             end
         end
         if too_close==true
-            break
+            continue;
         end
 
         for point in non_zeros

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -89,22 +89,21 @@ end
 
 """
 ```
-circle_centers, circle_radius = hough_circle_gradient(img, scale, min_dist, canny_thres, vote_thres, min_radius, max_radius)
+circle_centers, circle_radius = hough_circle_gradient(img_edges, img_phase, scale, min_dist, vote_thres, min_radius:max_radius)  
 ```
-Returns two vectors, corresponding to circle centers and radius.
-
-The circles are generated using a hough transform variant in which a non-zero point only votes for circle
-centers perpendicular to the local gradient.
-
-Parameters:
-    img          = image to detect circles in
-    scale        = relative accumulator resolution factor
-    min_dist     = minimum distance between detected circle centers
-    canny_thres  = upper threshold for canny, lower threshold=upper threshold/4
-    vote_thres   = accumulator threshold for circle detection
-    min_radius   = minimum circle radius
-    max_radius   = maximum circle radius
-"""
+Returns two vectors, corresponding to circle centers and radius.  
+  
+The circles are generated using a hough transform variant in which a non-zero point only votes for circle  
+centers perpendicular to the local gradient.  
+  
+Parameters:  
+-   `img_edges`    = edges of the image  
+-   `img_phase`    = phase of the gradient image   
+-   `scale`        = relative accumulator resolution factor  
+-   `min_dist`     = minimum distance between detected circle centers  
+-   `vote_thres`   = accumulator threshold for circle detection  
+-   `min_radius:max_radius`   = circle radius range  
+"""  
 
 function hough_circle_gradient{T<:Number}(
         img_edges::AbstractArray{Bool,2}, img_phase::AbstractArray{T,2},
@@ -138,16 +137,16 @@ function hough_circle_gradient{T<:Number}(
     for j in indices(img_edges, 2)::AbstractUnitRange{Int}
         for i in indices(img_edges, 1)::AbstractUnitRange{Int}
             if img_edges[i,j]
-                sin_theta = -cos(img_phase[i,j]);
-                cos_theta = sin(img_phase[i,j]);
+                sinθ = -cos(img_phase[i,j]);
+                cosθ = sin(img_phase[i,j]);
 
                 for r in radii
-                    x=(i+r*sin_theta)/scale
-                    y=(j+r*cos_theta)/scale
+                    x=(i+r*sinθ)/scale
+                    y=(j+r*cosθ)/scale
                     vote!(votes, x, y)
 
-                    x=(i-r*sin_theta)/scale
-                    y=(j-r*cos_theta)/scale
+                    x=(i-r*sinθ)/scale
+                    y=(j-r*cosθ)/scale
                     vote!(votes, x, y)
                 end
                 push!(non_zeros, CartesianIndex{2}(i,j));

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -135,8 +135,8 @@ function hough_circle_gradient{N<:Bool, T<:Number}(
         end
     end
 
-    for j in indices(img_edges, 2)
-        for i in indices(img_edges, 1)
+    for j in indices(img_edges, 2)::AbstractUnitRange{Int}
+        for i in indices(img_edges, 1)::AbstractUnitRange{Int}
             if img_edges[i,j]!=0
                 sin_theta = -cos(img_phase[i,j]);
                 cos_theta = sin(img_phase[i,j]);
@@ -164,11 +164,11 @@ function hough_circle_gradient{N<:Bool, T<:Number}(
     sort!(centers, lt=(a, b) -> votes[a]>votes[b])
 
     dist(a, b) = sqrt(sum(abs2, (a-b).I))
-    votes=Array(Int, Int(floor(dist(f,l))+1))
+    radius_votes=Array(Int, Int(floor(dist(f,l))+1))
 
     for center in centers
         center=(center-1)*scale
-        fill!(votes, 0)
+        fill!(radius_votes, 0)
 
         too_close=false
         for circle_center in circle_centers
@@ -182,10 +182,10 @@ function hough_circle_gradient{N<:Bool, T<:Number}(
         end
 
         for point in non_zeros
-            votes[Int(floor(dist(center, point)/scale))+1]+=1
+            radius_votes[Int(floor(dist(center, point)/scale))+1]+=1
         end
 
-        voters, radius = findmax(votes)
+        voters, radius = findmax(radius_votes)
         radius-=1
 
         if voters>vote_thres

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -86,3 +86,112 @@ function hough_transform_standard{T<:Union{Bool,Gray{Bool}}}(
     lines
 
 end
+
+"""
+```
+circle_centers, circle_radius = hough_circle_gradient(img, scale, min_dist, canny_thres, vote_thres, min_radius, max_radius)
+```
+Returns two vectors, corresponding to circle centers and radius.
+
+The circles are generated using a hough transform variant in which a non-zero point only votes for circle
+centers perpendicular to the local gradient.
+
+Parameters:
+    img          = image to detect circles in
+    scale        = relative accumulator resolution factor
+    min_dist     = minimum distance between detected circle centers
+    canny_thres  = upper threshold for canny, lower threshold=upper threshold/4
+    vote_thres   = accumulator threshold for circle detection
+    min_radius   = minimum circle radius
+    max_radius   = maximum circle radius
+"""
+
+function hough_circle_gradient{T<:Integer}(
+        img::AbstractArray{T,2},
+        scale::Number, min_dist::Number,
+        canny_thres::Number, vote_thres::Number,
+        min_radius::Integer, max_radius::Integer)
+
+    rows,cols=size(img)
+
+    img_edges = canny(img, 1, canny_thres, canny_thres/4, percentile=false)
+    dx, dy=imgradients(img, KernelFactors.ando3)
+    _, img_phase = magnitude_phase(dx, dy)
+
+    non_zeros=CartesianIndex{2}[]
+    centers=CartesianIndex{2}[]
+    circle_centers=CartesianIndex{2}[]
+    circle_radius=Integer[]
+    votes=zeros(Integer, Int(floor(rows/scale))+1, Int(floor(cols/scale))+1)
+
+    f = CartesianIndex(map(r->first(r), indices(votes)))
+    l = CartesianIndex(map(r->last(r), indices(votes)))
+
+    for i in indices(img, 1)
+        for j in indices(img, 2)
+            if img_edges[i,j]!=0
+                sin_theta = -cos(img_phase[i,j]);
+                cos_theta = sin(img_phase[i,j]);
+
+                for r in min_radius:max_radius
+                    x=Int(floor((i+r*sin_theta)/scale))+1
+                    y=Int(floor((j+r*cos_theta)/scale))+1
+                    p=CartesianIndex(x,y)
+
+                    if min(f,p)==f && max(l,p)==l
+                        votes[p]+=1
+                    end
+
+                    x=Int(floor((i-r*sin_theta)/scale))+1
+                    y=Int(floor((j-r*cos_theta)/scale))+1
+                    p=CartesianIndex(x,y)
+
+                    if min(f,p)==f && max(l,p)==l
+                        votes[p]+=1
+                    end
+                end
+                push!(non_zeros, CartesianIndex{2}(i,j));
+            end
+        end
+    end
+
+    for i in findlocalmaxima(votes)
+        if votes[i]>vote_thres
+            push!(centers, i);
+        end
+    end
+
+    sort!(centers, lt=(a, b) -> votes[a]>votes[b])
+
+    dist(a, b) = sqrt(sum(abs2, (a-b).I))
+    votes=Array(Integer, Int(floor(dist(f,l))+1))
+
+    for center in centers
+        center=(center-1)*scale
+        fill!(votes, 0)
+
+        too_close=false
+        for circle_center in circle_centers
+            if dist(center, circle_center)< min_dist
+                too_close=true
+                break
+            end
+        end
+        if too_close==true
+            break
+        end
+
+        for point in non_zeros
+            votes[Int(floor(dist(center, point)/scale))+1]+=1
+        end
+
+        voters, radius = findmax(votes)
+        radius-=1
+
+        if voters>vote_thres
+            push!(circle_centers, center)
+            push!(circle_radius, radius)
+        end
+    end
+    return circle_centers, circle_radius
+end

--- a/test/houghtransform.jl
+++ b/test/houghtransform.jl
@@ -44,13 +44,13 @@ using ImageFeatures
     img=zeros(Integer, 300, 300)
     for i in CartesianRange(size(img))
         if dist(i, CartesianIndex(100, 100))<25 || dist(i, CartesianIndex(200, 200))<50
-            img[i]=255
+            img[i]=1
         else
             img[i]=0
         end
     end
 
-    img_edges = canny(img, 1, 0.8, 0.2, percentile=false)
+    img_edges = canny(img, 1, 0.2, 0.1, percentile=false)
     dx, dy=imgradients(img, KernelFactors.ando3)
     _, img_phase = magnitude_phase(dx, dy)
 

--- a/test/houghtransform.jl
+++ b/test/houghtransform.jl
@@ -41,7 +41,7 @@ using ImageFeatures
 
     dist(a, b) = sqrt(sum(abs2, (a-b).I))
 
-    img=zeros(Integer, 300, 300)
+    img=zeros(Int, 300, 300)
     for i in CartesianRange(size(img))
         if dist(i, CartesianIndex(100, 100))<25 || dist(i, CartesianIndex(200, 200))<50
             img[i]=1

--- a/test/houghtransform.jl
+++ b/test/houghtransform.jl
@@ -52,7 +52,7 @@ using ImageFeatures
 
     img_edges = canny(img, 1, 0.2, 0.1, percentile=false)
     dx, dy=imgradients(img, KernelFactors.ando3)
-    _, img_phase = magnitude_phase(dx, dy)
+    img_phase = phase(dx, dy)
 
     centers, radii=hough_circle_gradient(img_edges, img_phase, 1, 40, 40, 5:75)
 

--- a/test/houghtransform.jl
+++ b/test/houghtransform.jl
@@ -50,7 +50,11 @@ using ImageFeatures
         end
     end
 
-    centers, radii=hough_circle_gradient(img, 1, 40, 0.8, 40, 5, 75)
+    img_edges = canny(img, 1, 0.8, 0.2, percentile=false)
+    dx, dy=imgradients(img, KernelFactors.ando3)
+    _, img_phase = magnitude_phase(dx, dy)
+
+    centers, radii=hough_circle_gradient(img_edges, img_phase, 1, 40, 40, 5:75)
 
     @test dist(centers[1], CartesianIndex(200,200))<5
     @test dist(centers[2], CartesianIndex(100,100))<5

--- a/test/houghtransform.jl
+++ b/test/houghtransform.jl
@@ -36,4 +36,26 @@ using ImageFeatures
         er = sum(map((t1,t2) -> abs(t1-t2), theta, [0, π/2, π/2, 0]))
         @test er <= 0.1
     end
+
+    @testset "Hough Circle Gradient" begin
+
+    dist(a, b) = sqrt(sum(abs2, (a-b).I))
+
+    img=zeros(Integer, 300, 300)
+    for i in CartesianRange(size(img))
+        if dist(i, CartesianIndex(100, 100))<25 || dist(i, CartesianIndex(200, 200))<50
+            img[i]=255
+        else
+            img[i]=0
+        end
+    end
+
+    centers, radii=hough_circle_gradient(img, 1, 40, 0.8, 40, 5, 75)
+
+    @test dist(centers[1], CartesianIndex(200,200))<5
+    @test dist(centers[2], CartesianIndex(100,100))<5
+    @test abs(radii[1]-50)<5
+    @test abs(radii[2]-25)<5
+
+    end
 end


### PR DESCRIPTION
Function for detecting circles in an grayscale image. Unlike the standard circle hough transform, first edges are computed and each edge pixel only votes for circle centers on the normal to the local gradient. For each suspected circle center, radius histogram is produced and the maxima is chosen is the radius. This has smaller space requirements compared to standard hough transform since we don't a 3d array. OpenCV uses the same algorithm for houghcircles.
The function returns two vectors corresponding to the circle centers and their radii. 

I haven't added tests yet.