### PR TITLE
Add Distributions.jl requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.add("Distributions")'  # Needed for Docs and Tests
-    - julia -e 'Pkg.add("TestImages")'  # Needed for Docs
-    - julia -e 'Pkg.add("ImageMagick")'  # Needed for Docs
-    - julia -e 'Pkg.add("Images")'  # Needed for Docs
-    - julia -e 'Pkg.clone("https://github.com/JuliaImages/ImageDraw.jl")' # Needed for Docs
     - julia -e 'Pkg.clone(pwd()); Pkg.build("ImageFeatures")'
     - julia -e 'Pkg.test("ImageFeatures", coverage=false)'
 after_success:
@@ -21,4 +16,5 @@ after_success:
     #      julia -e 'cd(Pkg.dir("ImageFeatures")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
     #   fi
     - julia -e 'Pkg.add("Documenter")'
+    - julia -e 'Pkg.clone("https://github.com/JuliaImages/ImageDraw.jl")' # Needed for Docs
     - julia -e 'cd(Pkg.dir("ImageFeatures")); include(joinpath("docs", "make.jl"))'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,5 @@
 julia 0.5
+ColorTypes
 Images 0.5
-Colors 0.6
-ColorVectorSpace 0.1
 Distributions 0.12
 FixedPointNumbers 0.1
-FileIO
-Compat 0.7.15
-StatsBase

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,6 +2,7 @@ julia 0.5
 Images 0.5
 Colors 0.6
 ColorVectorSpace 0.1
+Distributions 0.12
 FixedPointNumbers 0.1
 FileIO
 Compat 0.7.15

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,6 +1,6 @@
+Colors
 FactCheck
 TestImages
 @linux ImageMagick
 @windows ImageMagick
 @osx QuartzImageIO
-Distributions

--- a/test/brisk.jl
+++ b/test/brisk.jl
@@ -1,4 +1,4 @@
-using FactCheck, Images, ImageFeatures, TestImages, Distributions, ColorTypes, TestImages
+using FactCheck, Images, ImageFeatures, TestImages, Distributions, ColorTypes
 
 facts("BRISK") do 
     

--- a/test/freak.jl
+++ b/test/freak.jl
@@ -1,4 +1,4 @@
-using FactCheck, Images, ImageFeatures, TestImages, Distributions, ColorTypes, TestImages
+using FactCheck, Images, ImageFeatures, TestImages, Distributions, ColorTypes
 
 facts("FREAK") do 
     

--- a/test/lbp.jl
+++ b/test/lbp.jl
@@ -1,4 +1,4 @@
-using FactCheck, Base.Test, Images, Colors, FixedPointNumbers, ImageFeatures, TestImages
+using FactCheck, Base.Test, Images, Colors, FixedPointNumbers, ImageFeatures
 
 facts("Local Binary Patterns") do
 

--- a/test/orb.jl
+++ b/test/orb.jl
@@ -1,4 +1,4 @@
-using FactCheck, Images, ImageFeatures, TestImages, Distributions, TestImages
+using FactCheck, Images, ImageFeatures, TestImages, Distributions
 
 facts("ORB") do 
     


### PR DESCRIPTION
When doing `Pkg.clone("https://github.com/JuliaImages/ImageFeatures.jl")` on my local machine in Julia 0.5 I discovered that Distributions is a required package.