### PR TITLE
Updates for julia 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ ColorTypes
 Images 0.6
 Distributions 0.12
 FixedPointNumbers 0.3
+Compat 0.17

--- a/src/ImageFeatures.jl
+++ b/src/ImageFeatures.jl
@@ -1,3 +1,5 @@
+__precompile__(true)
+
 module ImageFeatures
 
 # package code goes here

--- a/src/ImageFeatures.jl
+++ b/src/ImageFeatures.jl
@@ -4,6 +4,7 @@ module ImageFeatures
 
 # package code goes here
 using Images, ColorTypes, FixedPointNumbers, Distributions
+using Compat
 
 include("core.jl")
 include("const.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,4 +1,4 @@
-abstract Params
+@compat abstract type Params end
 
 """
 ```
@@ -8,7 +8,7 @@ keypoint = Keypoint(feature)
 
 A `Keypoint` may be created by passing the coordinates of the point or from a feature.
 """
-typealias Keypoint CartesianIndex{2}
+const Keypoint = CartesianIndex{2}
 
 """
 ```
@@ -18,7 +18,7 @@ keypoints = Keypoints(features)
 
 Creates a `Vector{Keypoint}` of the `true` values in a boolean image or from a list of features.
 """
-typealias Keypoints Vector{CartesianIndex{2}}
+const Keypoints = Vector{CartesianIndex{2}}
 
 """
 ```
@@ -42,7 +42,7 @@ features = Features(keypoints)
 Returns a `Vector{Feature}` of features generated from the `true` values in a boolean image or from a
 list of keypoints.
 """
-typealias Features Vector{Feature}
+const Features = Vector{Feature}
 
 Feature(k::Keypoint) = Feature(k, 0.0, 0.0)
 
@@ -61,9 +61,9 @@ end
 
 Keypoints(features::Features) = map(f -> f.keypoint, features)
 
-typealias OrientationPair Tuple{Int16, Int16}
-typealias OrientationWeights Tuple{Float16, Float16}
-typealias SamplePair Tuple{Float16, Float16}
+const OrientationPair = Tuple{Int16, Int16}
+const OrientationWeights = Tuple{Float16, Float16}
+const SamplePair = Tuple{Float16, Float16}
 
 """
 ```
@@ -72,7 +72,7 @@ distance = hamming_distance(desc_1, desc_2)
 
 Calculates the hamming distance between two descriptors.
 """
-hamming_distance(desc_1, desc_2) = mean(desc_1 $ desc_2)
+hamming_distance(desc_1, desc_2) = mean(xor.(desc_1, desc_2))
 
 """
 ```


### PR DESCRIPTION
This fixes deprecation warnings on julia 0.6. However, it doesn't pass, because the `lbp` test triggers an illegal instruction error:

```julia
$ julia-0.6 --check-bounds=yes
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.6.0-pre.alpha.306 (2017-03-29 09:24 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 1eb51b6* (3 days old master)
|__/                   |  x86_64-linux-gnu

julia> include("lbp.jl")
Test Summary: | Pass  Total
Original      |    8      8
Test Summary: | Pass  Total
Uniform       |    7      7
Test Summary: | Pass  Total
Modified      |    4      4
Test Summary:      | Pass  Total
Rotation Invariant |    9      9
Test Summary:   | Pass  Total
Direction Coded |    4      4
Test Summary: | Pass  Total
Multi Block   |    2      2

signal (4): Illegal instruction
while loading /home/tim/.julia/v0.6/ImageFeatures/test/lbp.jl, in expression starting on line 241
macro expansion at /home/tim/.julia/v0.6/ImageFeatures/test/lbp.jl:253 [inlined]
macro expansion at ./test.jl:853 [inlined]
anonymous at ./<missing> (unknown line)
jl_call_fptr_internal at /home/tim/src/julia-0.6/src/julia_internal.h:326 [inlined]
jl_call_method_internal at /home/tim/src/julia-0.6/src/julia_internal.h:345 [inlined]
jl_toplevel_eval_flex at /home/tim/src/julia-0.6/src/toplevel.c:589
jl_parse_eval_all at /home/tim/src/julia-0.6/src/ast.c:873
jl_load at /home/tim/src/julia-0.6/src/toplevel.c:616
include_from_node1 at ./loading.jl:539
unknown function (ip: 0x7fa076df22db)
jl_call_fptr_internal at /home/tim/src/julia-0.6/src/julia_internal.h:326 [inlined]
jl_call_method_internal at /home/tim/src/julia-0.6/src/julia_internal.h:345 [inlined]
jl_apply_generic at /home/tim/src/julia-0.6/src/gf.c:2234
include at ./sysimg.jl:14
unknown function (ip: 0x7fa076c948bb)
jl_call_fptr_internal at /home/tim/src/julia-0.6/src/julia_internal.h:326 [inlined]
jl_call_method_internal at /home/tim/src/julia-0.6/src/julia_internal.h:345 [inlined]
jl_apply_generic at /home/tim/src/julia-0.6/src/gf.c:2234
do_call at /home/tim/src/julia-0.6/src/interpreter.c:75
eval at /home/tim/src/julia-0.6/src/interpreter.c:242
jl_interpret_toplevel_expr at /home/tim/src/julia-0.6/src/interpreter.c:34
jl_toplevel_eval_flex at /home/tim/src/julia-0.6/src/toplevel.c:577
jl_toplevel_eval_in at /home/tim/src/julia-0.6/src/builtins.c:484
eval at ./boot.jl:235
eval at ./REPL.jl:3
unknown function (ip: 0x7f9e67900556)
jl_call_fptr_internal at /home/tim/src/julia-0.6/src/julia_internal.h:326 [inlined]
jl_call_method_internal at /home/tim/src/julia-0.6/src/julia_internal.h:345 [inlined]
jl_apply_generic at /home/tim/src/julia-0.6/src/gf.c:2234
eval_user_input at ./REPL.jl:66
unknown function (ip: 0x7f9e67900f96)
jl_call_fptr_internal at /home/tim/src/julia-0.6/src/julia_internal.h:326 [inlined]
jl_call_method_internal at /home/tim/src/julia-0.6/src/julia_internal.h:345 [inlined]
jl_apply_generic at /home/tim/src/julia-0.6/src/gf.c:2234
macro expansion at ./REPL.jl:97 [inlined]
#1 at ./event.jl:73
unknown function (ip: 0x7f9e678fda7f)
jl_call_fptr_internal at /home/tim/src/julia-0.6/src/julia_internal.h:326 [inlined]
jl_call_method_internal at /home/tim/src/julia-0.6/src/julia_internal.h:345 [inlined]
jl_apply_generic at /home/tim/src/julia-0.6/src/gf.c:2234
jl_apply at /home/tim/src/julia-0.6/src/julia.h:1416 [inlined]
start_task at /home/tim/src/julia-0.6/src/task.c:261
unknown function (ip: 0xffffffffffffffff)
Allocations: 22160164 (Pool: 22158164; Big: 2000); GC: 27
/home/tim/bin/julia-0.6: line 2: 32070 Illegal instruction     (core dumped) ~/src/julia-0.6/julia "$@"
```

Interestingly, if you comment out the `@testset "Descriptor" begin` and complementary `end`, then there's no error.

This is clearly a julia bug; I don't yet have a simple reproducer, which is why I haven't reported it yet.