### PR TITLE
Avoid copying all column of gradient magnitude

### DIFF
--- a/src/hog.jl
+++ b/src/hog.jl
@@ -47,7 +47,7 @@ function create_descriptor(img::AbstractArray{CT, 2}, params::HOG) where CT<:Ima
 
     for j in indices(mag, 3)
         for i in indices(mag, 2)
-            ind = indmax(mag[:, i, j])
+            ind = indmax(view(mag, :, i, j))
             max_mag[i, j] = mag[ind, i, j]
             max_phase[i, j] = phase[ind, i, j]
         end


### PR DESCRIPTION
The copy for each column of the magnitude can be avoided. I will try to thing of a nice way also to have a `create_descriptor!` that allows to reuse memory.

This little change makes the computation of the hogs for the pedestrian exampe from 
```
  4.999339 seconds (93.52 M allocations: 4.218 GiB, 21.52% gc time)
```
to
```
  4.556243 seconds (85.95 M allocations: 3.880 GiB, 21.07% gc time)
```
There are plenty of things still to improve. Specially having a `create_descriptor!` method would be handy.