### PR TITLE
switch to new registrator and drop CI support for julia 0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 docs/build/
 docs/site/
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,25 @@ os:
     - linux
     - osx
 julia:
+    - 1.0
+    - 1.1
     - nightly
-    - 0.7
-    - 1.0.0
 notifications:
     email: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("ImageFeatures")'
-    # used in tests and Documentation (just install once)
-    - julia -e 'using Pkg; Pkg.add("TestImages")'
-    - julia -e 'using Pkg; if Sys.islinux() Pkg.add("ImageMagick") end'
-    - julia -e 'using Pkg; Pkg.test("ImageFeatures", coverage=true)'
+
+# use default travis script for test
+
+jobs:
+include:
+  - stage: deploy
+    julia: 1.0
+    os: linux
+    script:
+      - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageFeatures")'
+      - julia -e 'import Pkg; Pkg.add("Documenter")'
+      - julia -e 'using Pkg; Pkg.add("ImageDraw.jl")' # Needed for Docs
+      - julia -e 'using Pkg; import ImageFeatures; cd(joinpath(dirname(pathof(ImageFeatures)), "..")); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'
+
 after_success:
-    - julia -e 'using Pkg; import ImageFeatures; cd(joinpath(dirname(pathof(ImageFeatures)), "..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-    - julia -e 'using Pkg; Pkg.add("Documenter")'
-    - julia -e 'using Pkg; Pkg.add("ImageDraw.jl")' # Needed for Docs
-    - julia -e 'using Pkg; import ImageFeatures; cd(joinpath(dirname(pathof(ImageFeatures)), "..")); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'
+  # push coverage results to Codecov
+  - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,15 @@ notifications:
 # use default travis script for test
 
 jobs:
-include:
-  - stage: deploy
-    julia: 1.0
-    os: linux
-    script:
-      - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageFeatures")'
-      - julia -e 'import Pkg; Pkg.add("Documenter")'
-      - julia -e 'using Pkg; Pkg.add("ImageDraw.jl")' # Needed for Docs
-      - julia -e 'using Pkg; import ImageFeatures; cd(joinpath(dirname(pathof(ImageFeatures)), "..")); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'
-
+  include:
+    - stage: deploy
+      julia: 1.0
+      os: linux
+      script:
+        # - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("ImageCore")'
+        - julia -e 'import Pkg; Pkg.add("Documenter")'
+        - julia -e 'using Pkg; Pkg.add("ImageDraw.jl")' # Needed for Docs
+        - julia -e 'using Pkg; import ImageFeatures; cd(joinpath(dirname(pathof(ImageFeatures)), "..")); ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs", "make.jl"))'
 after_success:
   # push coverage results to Codecov
   - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,9 @@ version = "0.3.0"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Distributions = ">= 0.12"
@@ -16,12 +19,10 @@ julia = ">= 1.0"
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Colors", "Images", "ImageMagick", "QuartzImageIO", "Random", "SparseArrays", "Test", "TestImages"]
+test = ["Colors", "ImageMagick", "LinearAlgebra", "QuartzImageIO", "Test", "TestImages"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,27 @@
+name = "ImageFeatures"
+uuid = "92ff4b2b-8094-53d3-b29d-97f740f06cef"
+version = "0.3.0"
+
+[deps]
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+
+[compat]
+Distributions = ">= 0.12"
+FixedPointNumbers = ">= 0.3"
+Images = ">= 0.6"
+julia = ">= 0.7"
+
+[extras]
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
+
+[targets]
+test = ["Colors", "Images", "ImageMagick", "QuartzImageIO", "Random", "SparseArrays", "Test", "TestImages"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Distributions = ">= 0.12"
 FixedPointNumbers = ">= 0.3"
 Images = ">= 0.6"
-julia = ">= 0.7"
+julia = ">= 1.0"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 0.7
-ColorTypes
-Images 0.6
-Distributions 0.12
-FixedPointNumbers 0.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
-  - julia_version: 1
+  - julia_version: 1.0
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,0 @@
-Colors
-TestImages
-@linux ImageMagick
-@windows ImageMagick
-@osx QuartzImageIO


### PR DESCRIPTION
I also rewrite the travis script in a cleaner way.

More details: https://github.com/JuliaImages/Images.jl/issues/798

Blocking package:

- [x] Images: https://github.com/JuliaImages/Images.jl/pull/800
- [x] FixedPointNumbers https://github.com/JuliaMath/FixedPointNumbers.jl/pull/119
~- [ ] QuartzImageIO: https://github.com/JuliaIO/QuartzImageIO.jl/pull/56~