### PR TITLE
update package versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,28 +1,23 @@
 name = "ImageFeatures"
 uuid = "92ff4b2b-8094-53d3-b29d-97f740f06cef"
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Distributions = ">= 0.12"
-FixedPointNumbers = ">= 0.3"
-Images = ">= 0.6"
-julia = ">= 1.0"
+Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
+Images = "0.18, 0.19, 0.20"
+julia = "1"
 
 [extras]
-Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["Colors", "ImageMagick", "LinearAlgebra", "QuartzImageIO", "Test", "TestImages"]
+test = ["ImageMagick", "LinearAlgebra", "Test", "TestImages"]

--- a/src/ImageFeatures.jl
+++ b/src/ImageFeatures.jl
@@ -1,7 +1,7 @@
 module ImageFeatures
 
 # package code goes here
-using Images, ColorTypes, FixedPointNumbers, Distributions
+using Images, Distributions
 using SparseArrays
 import Random.seed!
 

--- a/test/brisk.jl
+++ b/test/brisk.jl
@@ -1,4 +1,4 @@
-using Test, ImageFeatures, Images, TestImages, Distributions, ColorTypes
+using Test, ImageFeatures, Images, TestImages, Distributions
 
 @testset "Testing brisk params" begin
     brisk_params = BRISK(pattern_scale = 2.0)
@@ -7,7 +7,7 @@ using Test, ImageFeatures, Images, TestImages, Distributions, ColorTypes
     @test brisk_params.pattern_table == pt
     @test brisk_params.smoothing_table == st
 end
-    
+
 @testset "Testing with Standard Images - Lighthouse (Rotation 45)" begin
     img = testimage("lighthouse")
     img_array_1 = convert(Array{Gray}, img)

--- a/test/corner.jl
+++ b/test/corner.jl
@@ -1,4 +1,4 @@
-using Test, ImageFeatures, Images, ColorTypes
+using Test, ImageFeatures, Images
 
 @testset "Orientations" begin
     img = zeros(20, 20)

--- a/test/freak.jl
+++ b/test/freak.jl
@@ -1,4 +1,4 @@
-using Test, ImageFeatures, Images, TestImages, Distributions, ColorTypes
+using Test, ImageFeatures, Images, TestImages, Distributions
 
 @testset "Test freak params" begin
     freak_params = FREAK(pattern_scale = 20.0)
@@ -7,7 +7,7 @@ using Test, ImageFeatures, Images, TestImages, Distributions, ColorTypes
     @test freak_params.pattern_table == pt
     @test freak_params.smoothing_table == st
 end
-    
+
 @testset "Testing with Standard Images - Lighthouse (Rotation 45)" begin
     img = testimage("lighthouse")
     img_array_1 = convert(Array{Gray}, img)

--- a/test/lbp.jl
+++ b/test/lbp.jl
@@ -1,4 +1,4 @@
-using Test, ImageFeatures, Images, Colors, FixedPointNumbers
+using Test, ImageFeatures, Images
 
 @testset "circular_offsets" begin
     img = [  0x4c  0x19  0xac  0x2e  0x8c  0xcc  0x96  0x4c  0xdb  0x4f
@@ -12,10 +12,10 @@ using Test, ImageFeatures, Images, Colors, FixedPointNumbers
              0x9a  0x74  0xd8  0x2f  0x38  0x4e  0x4b  0x18  0x4a  0xc7
              0x1a  0xe0  0x52  0x5a  0x6a  0x03  0xe8  0xcb  0x95  0xfc
           ]
-    
+
     global img_gray = map(i -> Images.Gray(reinterpret(N0f8, i)), img)
 end
- 
+
 @test ImageFeatures.circular_offsets(8, 1) == [ (-0.0,1.0), (-0.70711,0.70711), (-1.0,0.0), (-0.70711,-0.70711), (-0.0,-1.0), (0.70711,-0.70711), (1.0,-0.0), (0.70711,0.70711)]
 
 @testset "Original" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 module ImageFeatureTests
 
-using ImageFeatures, Images, TestImages, Distributions, ColorTypes
+using ImageFeatures, Images, TestImages, Distributions
 using Test
 using LinearAlgebra
 import Random.seed!


### PR DESCRIPTION
* Don't directly rely on ColorTypes, Colors and FixedPointNumbers
(https://github.com/JuliaImages/Images.jl/issues/802)
* Package versions incompatible to Julia v1.0 are dropped
* remove ">=" notation in compat section and leave compat maintainance work to
CompatHelper

Images.jl as a dependency is quite large, but for now, I'd like to leave it as it is since we haven't spent much on developing it recently.

cf. This PR blocks https://github.com/JuliaImages/juliaimages.github.io/pull/104
