### PR TITLE
Fix some depwarns

### DIFF
--- a/src/ImageFeatures.jl
+++ b/src/ImageFeatures.jl
@@ -69,6 +69,8 @@ export
     #Circles
     hough_circle_gradient
 
+_oneunit(i::CartesianIndex) = VERSION >= v"1.1" ? oneunit(i) : one(i)
+
 """
     desc, keypoints = create_descriptor(img, keypoints, params)
     desc, keypoints = create_descriptor(img, params)

--- a/src/corner.jl
+++ b/src/corner.jl
@@ -38,7 +38,7 @@ function corner_orientations(img::AbstractArray{T, 2}, corners::Keypoints, kerne
     orientations
 end
 
-corner_orientations(img::AbstractArray{T, 2}, corners::Keypoints, kernel::Array{K, 2}) where {T, K<:Real} = corner_orientations(convert(Array{Gray}, img), corners, kernel)
+corner_orientations(img::AbstractArray{T, 2}, corners::Keypoints, kernel::Array{K, 2}) where {T, K<:Real} = corner_orientations(Gray.(img), corners, kernel)
 
 function corner_orientations(img::AbstractArray, kernel::Array{K, 2}) where K<:Real
     corners = imcorner(img)

--- a/src/houghtransform.jl
+++ b/src/houghtransform.jl
@@ -42,7 +42,7 @@ julia> hough_transform_standard(img)
 1-element Array{Tuple{Float64,Float64},1}:
  (3.0, 1.5707963267948966)
 ```
-"""  
+"""
 function hough_transform_standard(
     img_edges::AbstractMatrix{Bool};
     stepsize=1,
@@ -115,17 +115,17 @@ end
 ```
 circle_centers, circle_radius = hough_circle_gradient(img_edges, img_phase, radii; scale=1, min_dist=minimum(radii), vote_threshold)
 ```
-Returns two vectors, corresponding to circle centers and radius.  
-  
-The circles are generated using a hough transform variant in which a non-zero point only votes for circle  
+Returns two vectors, corresponding to circle centers and radius.
+
+The circles are generated using a hough transform variant in which a non-zero point only votes for circle
 centers perpendicular to the local gradient. In case of concentric circles, only the largest circle is detected.
-  
-Parameters:  
--   `img_edges`    = edges of the image  
--   `img_phase`    = phase of the gradient image   
+
+Parameters:
+-   `img_edges`    = edges of the image
+-   `img_phase`    = phase of the gradient image
 -   `radii`        = circle radius range
--   `scale`        = relative accumulator resolution factor  
--   `min_dist`     = minimum distance between detected circle centers  
+-   `scale`        = relative accumulator resolution factor
+-   `min_dist`     = minimum distance between detected circle centers
 -   `vote_threshold`   = accumulator threshold for circle detection
 
 [`canny`](@ref) and [`phase`](@ref) can be used for obtaining img_edges and img_phase respectively.
@@ -151,7 +151,7 @@ julia> img_demo = Float64.(img_edges); for c in centers img_demo[c] = 2; end
 
 julia> imshow(img_demo)
 ```
-"""  
+"""
 function hough_circle_gradient(
         img_edges::AbstractArray{Bool,2},
         img_phase::AbstractArray{<:Number,2},
@@ -218,7 +218,7 @@ function hough_circle_gradient(
     radius_accumulator=Vector{Int}(undef, Int(floor(dist(f,l)/scale)+1))
 
     for center in centers
-        center=(center-1*one(center))*scale
+        center=(center-1*_oneunit(center))*scale
         fill!(radius_accumulator, 0)
 
         too_close=false

--- a/test/brief.jl
+++ b/test/brief.jl
@@ -153,7 +153,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Translation (100, 200))" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_array_2 = _warp(img_array_1, 100, 200)
 
     keypoints_1 = Keypoints(fastcorners(img_array_1, 12, 0.4))
@@ -169,7 +169,7 @@ end
 
 @testset "Testing with Standard Images - Lena (Translation (10, 20))" begin
     img = testimage("lena_gray_512")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_array_2 = _warp(img_array_1, 10, 20)
 
     keypoints_1 = Keypoints(fastcorners(img_array_1, 12, 0.4))

--- a/test/brisk.jl
+++ b/test/brisk.jl
@@ -10,7 +10,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 45)" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_array_2 = _warp(img_array_1, pi / 4)
 
     features_1 = Features(fastcorners(img_array_1, 12, 0.35))
@@ -27,7 +27,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 45, Translation (50, 40))" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, pi / 4)
     img_array_2 = _warp(img_temp_2, 50, 40)
 
@@ -44,7 +44,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 75, Translation (50, 40))" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, 5 * pi / 6)
     img_array_2 = _warp(img_temp_2, 50, 40)
 
@@ -61,7 +61,7 @@ end
 
 @testset "Testing with Standard Images - Lena (Rotation 45, Translation (10, 20))" begin
     img = testimage("lena_gray_512")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, pi / 4)
     img_array_2 = _warp(img_temp_2, 10, 20)
 

--- a/test/freak.jl
+++ b/test/freak.jl
@@ -10,7 +10,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 45)" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_array_2 = _warp(img_array_1, pi / 4)
 
     keypoints_1 = Keypoints(fastcorners(img_array_1, 12, 0.35))
@@ -26,7 +26,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 45, Translation (50, 40))" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, pi / 4)
     img_array_2 = _warp(img_temp_2, 50, 40)
 
@@ -43,7 +43,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 75, Translation (50, 40))" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, 5 * pi / 6)
     img_array_2 = _warp(img_temp_2, 50, 40)
 
@@ -60,7 +60,7 @@ end
 
 @testset "Testing with Standard Images - Lena (Rotation 45, Translation (10, 20))" begin
     img = testimage("lena_gray_512")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, pi / 4)
     img_array_2 = _warp(img_temp_2, 10, 20)
 

--- a/test/glcm.jl
+++ b/test/glcm.jl
@@ -5,7 +5,7 @@ using Test, ImageFeatures, Images
             0 0 1 1
             0 2 2 2
             2 2 3 3 ]
-    img_gray = convert(Array{Gray}, img / 3)
+    img_gray = Gray.(img / 3)
 
     glcm_mat = glcm(img, 1, 0, 4)
     expected_1 = [ 2 2 1 0

--- a/test/orb.jl
+++ b/test/orb.jl
@@ -13,7 +13,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 45)" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_array_2 = _warp(img_array_1, pi / 4)
 
     #Test Number of Keypoints returned
@@ -38,7 +38,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 45, Translation (50, 40))" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, pi / 4)
     img_array_2 = _warp(img_temp_2, 50, 40)
 
@@ -53,7 +53,7 @@ end
 
 @testset "Testing with Standard Images - Lighthouse (Rotation 75, Translation (50, 40))" begin
     img = testimage("lighthouse")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, 5 * pi / 6)
     img_array_2 = _warp(img_temp_2, 50, 40)
 
@@ -68,7 +68,7 @@ end
 
 @testset "Testing with Standard Images - Lena (Rotation 45, Translation (10, 20))" begin
     img = testimage("lena_gray_512")
-    img_array_1 = convert(Array{Gray}, img)
+    img_array_1 = Gray.(img)
     img_temp_2 = _warp(img_array_1, pi / 4)
     img_array_2 = _warp(img_temp_2, 10, 20)
 


### PR DESCRIPTION
These are mostly due to colorspace conversion. There is an `imhist` depwarn that this doesn't handle, but since `build_histogram` has some slight change in functionality I think it's best to make that a separate change.