### PR TITLE
Fix example blocks in the docs

### DIFF
--- a/docs/src/tutorials/brisk.md
+++ b/docs/src/tutorials/brisk.md
@@ -18,8 +18,7 @@ Let us take a look at a simple example where the BRISK descriptor is used to mat
 First, let us create the two images we will match using BRISK.
 
 ```@example 4
-
-using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations
+using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations, Rotations
 
 img = testimage("lighthouse")
 img1 = Gray.(img)
@@ -62,12 +61,10 @@ nothing # hide
 We can use the [ImageDraw.jl](https://github.com/JuliaImages/ImageDraw.jl) package to view the results.
 
 ```@example 4
-
 grid = hcat(img1, img2)
 offset = CartesianIndex(0, size(img1, 2))
 map(m -> draw!(grid, LineSegment(m[1], m[2] + offset)), matches)
 save("brisk_example.jpg", grid); nothing # hide
-
 ```
 
 ![](brisk_example.jpg)

--- a/docs/src/tutorials/freak.md
+++ b/docs/src/tutorials/freak.md
@@ -14,8 +14,7 @@ Let us take a look at a simple example where the FREAK descriptor is used to mat
 First, let us create the two images we will match using FREAK.
 
 ```@example 3
-
-using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations
+using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations, Rotations
 
 img = testimage("lighthouse")
 img1 = Gray.(img)
@@ -58,12 +57,10 @@ nothing # hide
 We can use the [ImageDraw.jl](https://github.com/JuliaImages/ImageDraw.jl) package to view the results.
 
 ```@example 3
-
 grid = hcat(img1, img2)
 offset = CartesianIndex(0, size(img1, 2))
 map(m -> draw!(grid, LineSegment(m[1], m[2] + offset)), matches)
 save("freak_example.jpg", grid); nothing # hide
-
 ```
 
 ![](freak_example.jpg)

--- a/docs/src/tutorials/orb.md
+++ b/docs/src/tutorials/orb.md
@@ -20,7 +20,7 @@ Let us take a look at a simple example where the ORB descriptor is used to match
 First, let us create the two images we will match using ORB.
 
 ```@example 2
-using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations
+using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations, Rotations
 
 img = testimage("lighthouse")
 img1 = Gray.(img)
@@ -55,12 +55,10 @@ nothing # hide
 We can use the [ImageDraw.jl](https://github.com/JuliaImages/ImageDraw.jl) package to view the results.
 
 ```@example 2
-
 grid = hcat(img1, img2)
 offset = CartesianIndex(0, size(img1, 2))
 map(m -> draw!(grid, LineSegment(m[1], m[2] + offset)), matches)
 save("orb_example.jpg", grid); nothing # hide
-
 ```
 
 ![](orb_example.jpg)


### PR DESCRIPTION
Currently, we don't have generated images in the docs. ([example](https://juliaimages.org/ImageFeatures.jl/v0.4.5/tutorials/brisk/))

![image](https://user-images.githubusercontent.com/7488140/119999601-e2137a80-c00c-11eb-835d-e195663626b8.png)

This PR fixes this problem.

![image](https://user-images.githubusercontent.com/7488140/120001155-73cfb780-c00e-11eb-814d-01ea4d3cebb8.png)