### PR TITLE
docs: upgrade dependencies and left align the table

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,4 +9,4 @@ Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.26"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,8 +2,10 @@
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ImageDraw = "4381153b-2b60-58ae-a1ba-fd683676385f"
+ImageFeatures = "92ff4b2b-8094-53d3-b29d-97f740f06cef"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [compat]

--- a/docs/src/tutorials/brief.md
+++ b/docs/src/tutorials/brief.md
@@ -24,10 +24,10 @@ Now, let us create the two images we will match using BRIEF.
 ```@example 1
 using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations
 
-img = testimage("lena_gray_512");
-img1 = Gray.(img);
+img = testimage("lighthouse")
+img1 = Gray.(img)
 trans = Translation(-100, -200)
-img2 = warp(img1, trans, axes(img1));
+img2 = warp(img1, trans, axes(img1))
 nothing # hide
 ```
 
@@ -49,8 +49,8 @@ nothing # hide
 Now pass the image with the keypoints and the parameters to the [`create_descriptor`](@ref) function.
 
 ```@example 1
-desc_1, ret_keypoints_1 = create_descriptor(img1, keypoints_1, brief_params);
-desc_2, ret_keypoints_2 = create_descriptor(img2, keypoints_2, brief_params);
+desc_1, ret_keypoints_1 = create_descriptor(img1, keypoints_1, brief_params)
+desc_2, ret_keypoints_2 = create_descriptor(img2, keypoints_2, brief_params)
 nothing # hide
 ```
 
@@ -64,7 +64,6 @@ nothing # hide
 We can use the [ImageDraw.jl](https://github.com/JuliaImages/ImageDraw.jl) package to view the results.
 
 ```@example 1
-
 grid = hcat(img1, img2)
 offset = CartesianIndex(0, size(img1, 2))
 map(m -> draw!(grid, LineSegment(m[1], m[2] + offset)), matches)

--- a/docs/src/tutorials/brisk.md
+++ b/docs/src/tutorials/brisk.md
@@ -18,8 +18,7 @@ Let us take a look at a simple example where the BRISK descriptor is used to mat
 First, let us create the two images we will match using BRISK.
 
 ```@example 4
-
-using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations
+using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations, Rotations
 
 img = testimage("lighthouse")
 img1 = Gray.(img)
@@ -62,12 +61,10 @@ nothing # hide
 We can use the [ImageDraw.jl](https://github.com/JuliaImages/ImageDraw.jl) package to view the results.
 
 ```@example 4
-
 grid = hcat(img1, img2)
 offset = CartesianIndex(0, size(img1, 2))
 map(m -> draw!(grid, LineSegment(m[1], m[2] + offset)), matches)
 save("brisk_example.jpg", grid); nothing # hide
-
 ```
 
 ![](brisk_example.jpg)

--- a/docs/src/tutorials/freak.md
+++ b/docs/src/tutorials/freak.md
@@ -14,8 +14,7 @@ Let us take a look at a simple example where the FREAK descriptor is used to mat
 First, let us create the two images we will match using FREAK.
 
 ```@example 3
-
-using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations
+using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations, Rotations
 
 img = testimage("lighthouse")
 img1 = Gray.(img)
@@ -58,12 +57,10 @@ nothing # hide
 We can use the [ImageDraw.jl](https://github.com/JuliaImages/ImageDraw.jl) package to view the results.
 
 ```@example 3
-
 grid = hcat(img1, img2)
 offset = CartesianIndex(0, size(img1, 2))
 map(m -> draw!(grid, LineSegment(m[1], m[2] + offset)), matches)
 save("freak_example.jpg", grid); nothing # hide
-
 ```
 
 ![](freak_example.jpg)

--- a/docs/src/tutorials/orb.md
+++ b/docs/src/tutorials/orb.md
@@ -20,7 +20,7 @@ Let us take a look at a simple example where the ORB descriptor is used to match
 First, let us create the two images we will match using ORB.
 
 ```@example 2
-using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations
+using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations, Rotations
 
 img = testimage("lighthouse")
 img1 = Gray.(img)
@@ -55,12 +55,10 @@ nothing # hide
 We can use the [ImageDraw.jl](https://github.com/JuliaImages/ImageDraw.jl) package to view the results.
 
 ```@example 2
-
 grid = hcat(img1, img2)
 offset = CartesianIndex(0, size(img1, 2))
 map(m -> draw!(grid, LineSegment(m[1], m[2] + offset)), matches)
 save("orb_example.jpg", grid); nothing # hide
-
 ```
 
 ![](orb_example.jpg)

--- a/src/brief.jl
+++ b/src/brief.jl
@@ -4,7 +4,7 @@ brief_params = BRIEF([size = 128], [window = 9], [sigma = 2 ^ 0.5], [sampling_ty
 ```
 
 | Argument | Type | Description |
-|----------|------|-------------|
+| :------- | :--- | :---------- |
 | **size** | Int | Size of the descriptor |
 | **window** | Int | Size of sampling window |
 | **sigma** | Float64 | Value of sigma used for inital gaussian smoothing of image |

--- a/src/brisk.jl
+++ b/src/brisk.jl
@@ -4,7 +4,7 @@ brisk_params = BRISK([pattern_scale = 1.0])
 ```
 
 | Argument | Type | Description |
-|----------|------|-------------|
+| :--------| :--- | :---------- |
 | `pattern_scale` | `Float64` | Scaling factor for the sampling window |
 """
 mutable struct BRISK <: Params

--- a/src/freak.jl
+++ b/src/freak.jl
@@ -4,7 +4,7 @@ freak_params = FREAK([pattern_scale = 22.0])
 ```
 
 | Argument | Type | Description |
-|----------|------|-------------|
+| :--------| :--- | :---------- |
 | **pattern_scale** | Float64 | Scaling factor for the sampling window |
 """
 mutable struct FREAK <: Params

--- a/src/orb.jl
+++ b/src/orb.jl
@@ -4,7 +4,7 @@ orb_params = ORB([num_keypoints = 500], [n_fast = 12], [threshold = 0.25], [harr
 ```
 
 | Argument | Type | Description |
-|----------|------|-------------|
+| :--------| :--- | :---------- |
 | **num_keypoints** | Int | Number of keypoints to extract and size of the descriptor calculated |
 | **n_fast** | Int | Number of consecutive pixels used for finding corners with FAST. See [`fastcorners`] |
 | **threshold** | Float64 | Threshold used to find corners in FAST. See [`fastcorners`] |


### PR DESCRIPTION
This PR includes the following updates:

## Fix image generation with `@example block`
In #94, I've added `using Rotations`, but the fix was incomplete and [the documentation](https://juliaimages.org/ImageFeatures.jl/dev/tutorials/brisk/) still doesn't include the generated images.
This was because `docs/Project.toml` doesn't have dependence to `Rotations`, and I've fixed this.

![image](https://user-images.githubusercontent.com/7488140/120057601-38b99c80-c07f-11eb-864e-fbd961bb86c0.png)

(This screenshot is from https://github.com/JuliaImages/ImageFeatures.jl/runs/2695863640?check_suite_focus=true)

## Replace Lena with Lighthouse
In [tutorials/brief section](https://juliaimages.org/ImageFeatures.jl/dev/tutorials/brief/), there was a warning.

>┌ Warning: Usage of "lena" is not recommended, and the image may be removed in a later release. See https://womenlovetech.com/losing-lena-why-we-need-to-remove-one-image-and-end-techs-original-sin/ for more information.
└ @ TestImages ~/.julia/packages/TestImages/mpUUF/src/TestImages.jl:89

I've updated the image to `testimage("lighthouse")`.

![image](https://user-images.githubusercontent.com/7488140/120057726-51768200-c080-11eb-926a-3a1eefa0aa30.png)

## Update version of Documenter.jl
`v0.24` to `v0.26`

## Markdown table alignment
Right-aligned
![image](https://user-images.githubusercontent.com/7488140/120057733-6521e880-c080-11eb-8c6b-6c0b53847e80.png)

to Left-aligned
![image](https://user-images.githubusercontent.com/7488140/120057746-7bc83f80-c080-11eb-92fe-300359223d50.png)
