### PR TITLE
docs: Add `using Images` for function reference

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, ImageFeatures
+using Documenter, ImageFeatures, Images
 
 makedocs(sitename = "ImageFeatures",
          format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),


### PR DESCRIPTION
On current document, some reference links (e.g. `fastcorners`) return 404.

![image](https://user-images.githubusercontent.com/7488140/120073513-937ce380-c0d3-11eb-8b67-9a04a0aaff4e.png)

https://juliaimages.org/ImageFeatures.jl/dev/tutorials/brief/

This PR fixes this problem by adding `using Images` to `docs/make.jl`.
