### PR TITLE
Speed up hamming distance for bit arrays

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -75,7 +75,7 @@ distance = hamming_distance(desc_1, desc_2)
 
 Calculates the hamming distance between two descriptors.
 """
-hamming_distance(desc_1, desc_2) = mean(xor.(desc_1, desc_2))
+hamming_distance(desc_1, desc_2) = sum(xor.(desc_1, desc_2)) / length(desc_1)
 
 """
 ```


### PR DESCRIPTION
The current `hamming_distance` is slow for bit arrays
```julia
julia> b1 = bitrand(512)

julia> b2 = bitrand(512)

julia> @btime hamming_distance($b1, $b2) # before
  773.562 ns (2 allocations: 160 bytes)
0.501953125
```
as `mean` converts the bits to floating-point numbers, sums them, and then divides the total by the number of bits. We can replace `mean(x)` with `sum(x)/length(x)`. If `x` is a bit array, `sum(x::AbstractArray{Bool})` calls `count(x)` which is much faster than summing floating-point numbers.
```julia
julia> @btime hamming_distance($b1, $b2) # after
  47.614 ns (2 allocations: 160 bytes)
0.501953125
```
About 10x speedup on `match_keypoints` in the following example.
```julia
using ImageFeatures, TestImages, Images, ImageDraw, CoordinateTransformations, Rotations

img = testimage("lighthouse")
img1 = Gray.(img)
rot = recenter(RotMatrix(5pi/6), [size(img1)...] .÷ 2)  # a rotation around the center
tform = rot ∘ Translation(-50, -40)
img2 = warp(img1, tform, axes(img1))

features_1 = Features(fastcorners(img1, 12, 0.35))
features_2 = Features(fastcorners(img2, 12, 0.35))

brisk_params = BRISK()

desc_1, ret_features_1 = create_descriptor(img1, features_1, brisk_params)
desc_2, ret_features_2 = create_descriptor(img2, features_2, brisk_params)

# before
julia> @btime match_keypoints(Keypoints(ret_features_1), Keypoints(ret_features_2), desc_1, desc_2, 0.1)
  422.808 ms (1011294 allocations: 87.96 MiB)

# after 
julia> @btime match_keypoints(Keypoints(ret_features_1), Keypoints(ret_features_2), desc_1, desc_2, 0.1)
  30.256 ms (1011294 allocations: 87.96 MiB)
```